### PR TITLE
Changing colors while moving

### DIFF
--- a/src/netcode/d_netcmd.c
+++ b/src/netcode/d_netcmd.c
@@ -5063,7 +5063,7 @@ static void Color_OnChange(void)
 			return;
 		}
 
-		if (!P_PlayerMoving(consoleplayer) && skincolors[players[consoleplayer].skincolor].accessible == true)
+		if (skincolors[players[consoleplayer].skincolor].accessible == true)
 		{
 			// Color change menu scrolling fix is no longer necessary
 			SendNameAndColor();


### PR DESCRIPTION
Not sure if you accept PRs, but thought I'd make one incase you do as I don't see anything about it (unless I'm blind).

Removes the check on movement while moving; this sends current player data (name, color, (default or current? can't actually find it so I'm probably stupid) skin) and can cause whackiness like changing skins while moving does (eg. metal hover as Knux if it is still active for skins; although i dont think sending player data can cause issues in vanilla, at best in addons).