### PR TITLE
`cvcycle` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ You can compile the source code normally (see "Compiling") and put the binary in
 - HUD camera struct updates position in first person! (credits [Jiskster](https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2629) & [Hanicef](https://git.do.srb2.org/Hanicef/SRB2Classic/-/commit/681bd160f5be3925a97d798d00e67b32a8c1df71))
 - `v.cachePatch` accepts a second parameter for rotation! (https://git.do.srb2.org/STJr/SRB2/-/merge_requests/2662)
 - Added "`TR`" as an alias to "`TICRATE`" in Lua
-- "`getlogfile`" command (Returns the absolute path of the current log, useful when latest-log.txt is sym-linked to a different log)
+- "`getlogfile`" command (Prints the absolute path of the current log, useful when latest-log.txt is sym-linked to a different log)
 
 ## GIFs
 - Adjustable gif size cap, toggable too! (`gif_maxsize`, "Max GIF Size (MB)")
     - ^ When gif is capped, gif_rolling allows for another gif to immediately start! (`gif_rolling`, "Keep recording when capped")
 - Pause GIFs *WHILE* Recording! (Bound to F2 by default)
 
-## Console
+## Console && Misc. Commands
 - `help` now lists commands and variables by origin. Parameters are as follows:
   | Param      | Desc      |
   | ------------- | ------------- |
@@ -65,6 +65,7 @@ You can compile the source code normally (see "Compiling") and put the binary in
   | `-a` | Only show variables and/or commands created by addons |
 
 - Console variables can no longer be used as an argument for `help`, they now print their info instead of just their current and default value. "`cvarinfo`" lets you hide the flags and origin sections ("Show All" by default).
+- "`cvcycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-r` is specified (starts at the first arg if so).
 
 # Lua Additions
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can compile the source code normally (see "Compiling") and put the binary in
   | `-a` | Only show variables and/or commands created by addons |
 
 - Console variables can no longer be used as an argument for `help`, they now print their info instead of just their current and default value. "`cvarinfo`" lets you hide the flags and origin sections ("Show All" by default).
-- "`cycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-b` is specified (starts at the first arg if so).
+- "`cycle`" command (`cycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-b` is specified (starts at the first arg if so).
 
 # Lua Additions
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can compile the source code normally (see "Compiling") and put the binary in
   | `-a` | Only show variables and/or commands created by addons |
 
 - Console variables can no longer be used as an argument for `help`, they now print their info instead of just their current and default value. "`cvarinfo`" lets you hide the flags and origin sections ("Show All" by default).
-- "`cvcycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-b` is specified (starts at the first arg if so).
+- "`cycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-b` is specified (starts at the first arg if so).
 
 # Lua Additions
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can compile the source code normally (see "Compiling") and put the binary in
   | `-a` | Only show variables and/or commands created by addons |
 
 - Console variables can no longer be used as an argument for `help`, they now print their info instead of just their current and default value. "`cvarinfo`" lets you hide the flags and origin sections ("Show All" by default).
-- "`cvcycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-r` is specified (starts at the first arg if so).
+- "`cvcycle`" command (`cvcycle <cvar> [values]`): Inaccessible by Lua. Cycles given values on the cvar if the current value is found in the list (also loops around). Fails if the current value is not found, unless `-b` is specified (starts at the first arg if so).
 
 # Lua Additions
 

--- a/src/command.c
+++ b/src/command.c
@@ -891,9 +891,6 @@ static void COM_Help_f(void)
 {
 	xcommand_t *cmd;
 	consvar_t *cvar;
-	// todo: this could be lowered to 5 booleans at the price of
-	// repeating a check, probably not worth. regardless this is
-	// too many booleans.
 	// Params for only showing certain origins (NOT type)
 	boolean parmv = COM_CheckPartialParm("-v");
 	boolean parmc = COM_CheckPartialParm("-c");

--- a/src/command.c
+++ b/src/command.c
@@ -1155,14 +1155,13 @@ static void COM_Toggle_f(void)
  * 
  * e.g.: "cvcycle color red white green"
  * 
- * THIS DOES _NOT_ CHECK CV_Immutable(). Don't expose to Lua, please.
- * 
 */
 static void COM_CVCycle_f(void)
 {
 	consvar_t *cvar;
 
-	boolean reiterateparm = COM_CheckPartialParm("-r");
+	boolean parmb = COM_CheckPartialParm("-b");
+	boolean parms = COM_CheckPartialParm("-s");
 
 	UINT16 arg = 2; // used for manually counting args
 	UINT16 args; // exists for the while loop, don't wanna spam call COM_Argc there
@@ -1172,7 +1171,7 @@ static void COM_CVCycle_f(void)
 	if (COM_Argc() < 4)
 	{
 		CONS_Printf("cvcycle <cvar> [values]: Cycle given values (can't be used on boolean cvars)\n\n");
-		CONS_Printf("\"-r\" can be specified at the end to start from the beginning IF the current value isn't in the list.\n");
+		CONS_Printf("\"-b\" can be specified at the end to start from the beginning IF the current value isn't in the list.\n");
 		return;
 	}
 
@@ -1185,18 +1184,17 @@ static void COM_CVCycle_f(void)
 	// i don't think theres a reason to make this toggle 2.0
 	if (cvar->PossibleValue == CV_YesNo || cvar->PossibleValue == CV_OnOff || cvar->PossibleValue == CV_TrueFalse)
 	{
-		CONS_Alert(CONS_NOTICE, "%s is a boolean variable, please use \"toggle\" instead\n", COM_Argv(1));
+		CONS_Alert(CONS_NOTICE, "%s is a boolean variable, use \"toggle\" instead\n", COM_Argv(1));
 		return;
 	}
 
-	args = (reiterateparm ? (COM_Argc()-1) : COM_Argc());
+	args = (COM_Argc()-(parms+parmb));
 
-	// really stupid argument iteration
-	// if it breaks, blame bagel for being an idiot
 	while (args > arg) {
-		if (((strcmp(COM_Argv(arg), cvar->string)) == 0) || (atoi(COM_Argv(arg)) == cvar->value))
+		if (!(strcmp(COM_Argv(arg), cvar->string)) || (atoi(COM_Argv(arg)) == cvar->value))
 		{
-			cvar->flags |= CV_SHOWMODIFONETIME;
+			if (!parms)
+				cvar->flags |= CV_SHOWMODIFONETIME;
 			if (args > (arg+1)) {
 				CV_Set(cvar, COM_Argv(arg+1));
 			} else { // loop backwards kthxbai
@@ -1207,12 +1205,13 @@ static void COM_CVCycle_f(void)
 		arg++;
 	}
 
-	if (reiterateparm) {
-		cvar->flags |= CV_SHOWMODIFONETIME;
+	if (parmb) {
+		if (!parms)
+			cvar->flags |= CV_SHOWMODIFONETIME;
 		CV_Set(cvar, COM_Argv(2));
 		return;
 	} else { // our guy is stupid
-		CONS_Alert(CONS_NOTICE, "Could not find current value and \"-r\" was not specified!\n");
+		CONS_Alert(CONS_NOTICE, "Could not find current value and \"-b\" was not specified!\n");
 		return;
 	}
 }
@@ -1225,7 +1224,7 @@ static void COM_Add_f(void)
 
 	if (COM_Argc() != 3)
 	{
-		CONS_Printf(M_GetText("Add <cvar_name> <value>: Add to the value of a cvar. Negative values work too!\n"));
+		CONS_Printf(M_GetText("Add <cvar> <value>: Add to the value of a cvar. Negative values work too!\n"));
 		return;
 	}
 	cvar = CV_FindVar(COM_Argv(1));

--- a/src/command.c
+++ b/src/command.c
@@ -51,6 +51,7 @@ static void COM_CEchoDuration_f(void);
 static void COM_Exec_f(void);
 static void COM_Wait_f(void);
 static void COM_Help_f(void);
+static void COM_CONSLogicC_f(void);
 static void COM_Find_f(void);
 static void COM_Toggle_f(void);
 static void COM_Cycle_f(void);
@@ -347,6 +348,7 @@ void COM_Init(void)
 	COM_AddCommand("exec", COM_Exec_f, 0);
 	COM_AddCommand("wait", COM_Wait_f, 0);
 	COM_AddCommand("help", COM_Help_f, COM_LUA);
+	COM_AddCommand("conslogiccount", COM_CONSLogicC_f, COM_CLIENT);
 	COM_AddCommand("find", COM_Find_f, COM_LUA);
 	COM_AddCommand("toggle", COM_Toggle_f, COM_LUA);
 	COM_AddCommand("add", COM_Add_f, COM_LUA);
@@ -880,34 +882,38 @@ static void COM_Wait_f(void)
 		com_wait = 1; // 1 frame
 }
 
-/** Prints help on variables and commands.
-  */
+/*
+*Prints help on variables and commands.
+* TODO: This thing has too many booleans. Seriously.
+* isitallfalse can be removed but that comes at the price of checking it each time
+*/
 static void COM_Help_f(void)
 {
 	xcommand_t *cmd;
 	consvar_t *cvar;
-	boolean foundflag = false;
+	// todo: this could be lowered to 5 booleans at the price of
+	// repeating a check, probably not worth. regardless this is
+	// too many booleans.
 	// Params for only showing certain origins (NOT type)
 	boolean parmv = COM_CheckPartialParm("-v");
 	boolean parmc = COM_CheckPartialParm("-c");
 	boolean parma = COM_CheckPartialParm("-a");
-
-	INT32 i = 0;
+	// is the current loop for commands? (iscomloop)
+	// did we even hit any CV_LUAVAR/COM_LUACOM? (foundflag)
+	boolean iscomloop = false, foundflag = false, isitallfalse = false;
 
 	// Okay, bear with me here: It aligns ingame.
 	if (COM_CheckPartialParm("-f")) {
-		if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3)) // feature-creeping.
-			CONS_Printf("FLAG\t\t\t\t   DESCRIPTION\n");
 
 		CONS_Printf("CV_SAVE\t\t\t | This variable saves to config.\n");
-		CONS_Printf("CV_CALL\t\t\t | Calls a function on changed.\n");
+		CONS_Printf("CV_CALL\t\t\t | Calls a function on change.\n");
 		CONS_Printf("CV_NETVAR\t\t\t | Sent to all connected clients on change.\n");
-		CONS_Printf("CV_NOINIT\t\t\t | No functions called when registered.\n");
+		CONS_Printf("CV_NOINIT\t\t\t | Don't call functions when registered.\n");
 		CONS_Printf("CV_FLOAT\t\t\t | Fixed 16 bits (int and frac), unit is FRACUNIT. Value is converted in possible values.\n");
 		CONS_Printf("CV_NOTINNET\t\t | Can't be changed in netgames, however ISN'T a netvar.\n");
 		CONS_Printf("CV_MODIFIED\t\t | This variable was modified.\n");
 		CONS_Printf("CV_SHOWMODIF\t\t | Show something when modified.\n");
-		CONS_Printf("CV_SHOWMODIFONETIME | Same as CV_SHOWMODIF, except resets to 0 when modified.\n");
+		CONS_Printf("CV_SHOWMODIFONETIME | Same as CV_SHOWMODIF, except is removed afterwards.\n");
 		CONS_Printf("CV_NOSHOWHELP\t\t | Does not appear in help list.\n");
 		// CV_HIDEN is unnecessary as those vars are outside the console
 		CONS_Printf("CV_CHEAT\t\t\t | Can only be used if cheats are enabled.\n");
@@ -930,11 +936,9 @@ static void COM_Help_f(void)
 				CONS_Printf("\x82""Command %s:\n", cmd->name);
 				CONS_Printf(M_GetText("  flags: "));
 
+				// fixme: enough said vvv
 				if (cmd->flags & COM_ADMIN)
 					CONS_Printf("COM_ADMIN ");
-
-				if (cmd->flags & COM_SPLITSCREEN)
-					CONS_Printf("COM_SPLITSCREEN ");
 
 				if (cmd->flags & COM_LOCAL)
 					CONS_Printf("COM_LOCAL ");
@@ -972,75 +976,111 @@ static void COM_Help_f(void)
 	}
 	else
 	{
-		// this is really dirty...
-		if ((!parmc && !parma) || parmv) {
-			CONS_Printf("\x83""Vanilla:""\x82""\n\tVariables: ");
-			for (cvar = consvar_vars; cvar; cvar = cvar->next)
-			{
-				if (cvar->flags & (CV_NOSHOWHELP | CV_CLIENT | CV_LUAVAR))
-					continue;
-				CONS_Printf("%s ", cvar->name);
-				i++;
-			}
-        CONS_Printf("\x82""\n\tCommands: ");
-        	for (cmd = com_commands; cmd; cmd = cmd->next)
-        	{
-            	if (cmd->flags & (COM_LUACOM | COM_CLIENT))
-                	continue;
-            CONS_Printf("%s ",cmd->name);
-            i++;
-        		}
-		}
-		if ((!parmv && !parma) || parmc) {
-			CONS_Printf(parmc ? "\x83""Client:""\x82""\n\tVariables: " : "\n\x83""Client:""\x82""\n\tVariables: ");
-			for (cvar = consvar_vars; cvar; cvar = cvar->next)
-			{
-				if (cvar->flags & (CV_NOSHOWHELP | CV_LUAVAR) || !(cvar->flags & CV_CLIENT))
-					continue;
-				CONS_Printf("%s ", cvar->name);
-				i++;
-			}
-        CONS_Printf("\n\x82""\tCommands: ");
-        for (cmd = com_commands; cmd; cmd = cmd->next)
-        {
-            if (!(cmd->flags & COM_CLIENT) || (cmd->flags & COM_LUACOM)) // if it has both, its someone messing with the flags table, count as addon instead
-                continue;
-            CONS_Printf("%s ",cmd->name);
-            i++;
-        }
-		}
-		if ((!parmv && !parmc) || parma) {
-			CONS_Printf(parma ? "\x83""Addons:""\x82""\n\tVariables: " : "\n\x83""Addons:""\x82""\n\tVariables: ");
-			for (cvar = consvar_vars; cvar; cvar = cvar->next)
-			{
-				if (cvar->flags & CV_NOSHOWHELP || !(cvar->flags & CV_LUAVAR))
-					continue;
-				CONS_Printf("%s ", cvar->name);
-				foundflag = true;
-				i++;
+		// logic count thing was moved to COM_CONSLogicC_f
+
+		// origin index (same order as helpheaders)
+		UINT8 oi = 0;
+
+		// only eval this once
+		isitallfalse = (!parmv && !parmc && !parma);
+
+		// slightly less ternary spam
+		const char* helpheaders[] = {"Vanilla", "Client", "Addons"};
+
+		while (oi <= 2)
+		{
+			if (!isitallfalse) {
+				if (!parmv && oi == 0)
+					oi++;
+				if (!parmc && oi == 1)
+					oi++;
+				if (!parma && oi == 2)
+					oi++;
 			}
 
-		if (!foundflag)
-			CONS_Printf("(no variables have been created by addons)");
-		foundflag = false;
+			foundflag = false;
+			if (!iscomloop) {
+				CONS_Printf("\x83%s\n\t""\x82Variables: \x80", helpheaders[oi]);
+				for (cvar = consvar_vars; cvar; cvar = cvar->next)
+				{
+					if (cvar->flags & CV_NOSHOWHELP)
+						continue;
+					
+					if (oi == 0 && cvar->flags & (CV_CLIENT | CV_LUAVAR))
+						continue;
+					
+					if (oi == 1 && (cvar->flags & CV_LUAVAR || !(cvar->flags & CV_CLIENT)))
+						continue;
 
-        CONS_Printf("\n\x82""\tCommands: ");
-        for (cmd = com_commands; cmd; cmd = cmd->next)
-        {
-            if (!(cmd->flags & COM_LUACOM))
-                continue;
-            CONS_Printf("%s ",cmd->name);
-			foundflag = true;
-            i++;
-        }
-		if (!foundflag)
-			CONS_Printf("(no commands have been created by addons)");
+					if (oi == 2 && !(cvar->flags & CV_LUAVAR))
+						continue;
+					
+					CONS_Printf("%s ", cvar->name);
+					if (oi == 2)
+						foundflag = true;
+				}
+			} else {
+				CONS_Printf("\x82""Commands: ""\x80");
+				for (cmd = com_commands; cmd; cmd = cmd->next)
+				{
+					// TODO: kill this with fire
+					
+					if (oi == 0 && cmd->flags & (COM_CLIENT | COM_LUACOM))
+						continue;
+					
+					if (oi == 1 && (cmd->flags & COM_LUACOM || !(cmd->flags & COM_CLIENT)))
+						continue;
+
+					if (oi == 2 && !(cmd->flags & COM_LUACOM))
+						continue;
+					
+					CONS_Printf("%s ", cmd->name);
+					if (oi == 2)
+						foundflag = true;
+				}
+			}
+
+			if (oi == 2 && !foundflag)
+				CONS_Printf("(no %s have been created by addons", (iscomloop ? "commands" : "variables"));
+
+			CONS_Printf("\n"); // new line right after
+			
+			// only increment if this is done
+			if (iscomloop) {
+				oi++;
+			}	
+
+			// gcc would optimize !bool probably so this is unneded but like
+			// just in case... since this *SHOULD* be a singular CPU instruction in theorem
+			iscomloop ^= 1;
 		}
 
 		CONS_Printf("\x82""\nCheck wiki.srb2.org for more or type help <command>. For info on flags, do \"help -f\".\n");
 
-		CONS_Debug(DBG_GAMELOGIC, "\x82Total : %d\n", i);
 	}
+}
+
+static void COM_CONSLogicC_f(void)
+{
+	xcommand_t *cmd;
+	consvar_t *cvar;
+	INT32 i = 0;
+
+	// (im just lazy to switch it off from CONS_Debug)
+	if (!(cv_debug & DBG_GAMELOGIC))
+		CONS_Printf("DEVMODE must be enabled and set to gamelogic to use this.\n");
+
+	for (cvar = consvar_vars; cvar; cvar = cvar->next)
+	{
+		i++;
+	}
+
+	for (cmd = com_commands; cmd; cmd = cmd->next)
+	{
+		i++;
+	}
+
+	CONS_Debug(DBG_GAMELOGIC, "\x82Total : %d\n", i);
 }
 
 static void COM_Find_f(void)

--- a/src/command.c
+++ b/src/command.c
@@ -53,7 +53,7 @@ static void COM_Wait_f(void);
 static void COM_Help_f(void);
 static void COM_Find_f(void);
 static void COM_Toggle_f(void);
-static void COM_CVCycle_f(void);
+static void COM_Cycle_f(void);
 static void COM_Add_f(void);
 
 
@@ -350,7 +350,7 @@ void COM_Init(void)
 	COM_AddCommand("find", COM_Find_f, COM_LUA);
 	COM_AddCommand("toggle", COM_Toggle_f, COM_LUA);
 	COM_AddCommand("add", COM_Add_f, COM_LUA);
-	COM_AddCommand("cvcycle", COM_CVCycle_f, COM_CLIENT); // doesn't check CV_Immutable(), add COM_LUA at own your risk.
+	COM_AddCommand("cycle", COM_Cycle_f, COM_CLIENT); // doesn't check CV_Immutable(), add COM_LUA at own your risk.
 	RegisterNetXCmd(XD_NETVAR, Got_NetVar);
 }
 
@@ -1153,10 +1153,10 @@ static void COM_Toggle_f(void)
  * meant to lessen the load on autoexec.cfgs having like 30 billion binds
  * half of those being changing some vars back.
  * 
- * e.g.: "cvcycle color red white green"
+ * e.g.: "cycle color red white green"
  * 
 */
-static void COM_CVCycle_f(void)
+static void COM_Cycle_f(void)
 {
 	consvar_t *cvar;
 
@@ -1170,7 +1170,7 @@ static void COM_CVCycle_f(void)
 
 	if (COM_Argc() < 4)
 	{
-		CONS_Printf("cvcycle <cvar> [values]: Cycle given values (can't be used on boolean cvars)\n\n");
+		CONS_Printf("cycle <cvar> [values]: Cycle given values (can't be used on boolean cvars)\n\n");
 		CONS_Printf("\"-b\" can be specified at the end to start from the beginning IF the current value isn't in the list.\n");
 		return;
 	}

--- a/src/command.c
+++ b/src/command.c
@@ -931,28 +931,30 @@ static void COM_Help_f(void)
 					continue;
 
 				CONS_Printf("\x82""Command %s:\n", cmd->name);
-				CONS_Printf(M_GetText("  flags: "));
+				if (!(cv_cvarinformation.value == 2 || cv_cvarinformation.value == 3)) {
+					CONS_Printf(M_GetText("  flags: "));
 
-				// fixme: enough said vvv
-				if (cmd->flags & COM_ADMIN)
-					CONS_Printf("COM_ADMIN ");
+					// fixme: enough said vvv
+					if (cmd->flags & COM_ADMIN)
+						CONS_Printf("COM_ADMIN ");
 
-				if (cmd->flags & COM_LOCAL)
-					CONS_Printf("COM_LOCAL ");
+					if (cmd->flags & COM_LOCAL)
+						CONS_Printf("COM_LOCAL ");
 
-				if (cmd->flags & COM_LUA)
-					CONS_Printf("COM_LUA ");
+					if (cmd->flags & COM_LUA)
+						CONS_Printf("COM_LUA ");
 
-				if (cmd->flags & COM_LUACOM)
-					CONS_Printf("COM_LUACOM ");
+					if (cmd->flags & COM_LUACOM)
+						CONS_Printf("COM_LUACOM ");
 
-				if (cmd->flags & COM_CLIENT)
-					CONS_Printf("COM_CLIENT ");
+					if (cmd->flags & COM_CLIENT)
+						CONS_Printf("COM_CLIENT ");
 
-				if (cmd->flags & COM_SPLITSCREEN)
-					CONS_Printf("COM_SPLITSCREEN");
-
-				CONS_Printf("\n");
+					if (cmd->flags & COM_SPLITSCREEN)
+						CONS_Printf("COM_SPLITSCREEN");
+			
+					CONS_Printf("\n");
+				}
 
 				if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3)) {
 					if (!(cmd->flags & (COM_LUACOM | COM_CLIENT))) {
@@ -1020,7 +1022,6 @@ static void COM_Help_f(void)
 				CONS_Printf("\x82""Commands: ""\x80");
 				for (cmd = com_commands; cmd; cmd = cmd->next)
 				{
-					// TODO: kill this with fire
 					
 					if (oi == 0 && cmd->flags & (COM_CLIENT | COM_LUACOM))
 						continue;
@@ -2660,7 +2661,10 @@ static boolean CV_Command(void)
 				CONS_Printf("CV_NOINIT ");
 
 			if (v->flags & CV_FLOAT)
+			{
 				CONS_Printf("CV_FLOAT ");
+				floatmode = true;
+			}
 
 			if (v->flags & CV_NOTINNET)
 				CONS_Printf("CV_NOTINNET ");

--- a/src/command.c
+++ b/src/command.c
@@ -931,7 +931,8 @@ static void COM_Help_f(void)
 					continue;
 
 				CONS_Printf("\x82""Command %s:\n", cmd->name);
-				if (!(cv_cvarinformation.value == 2 || cv_cvarinformation.value == 3)) {
+				if (!(cv_cvarinformation.value == 2 || cv_cvarinformation.value == 3))
+				{
 					CONS_Printf(M_GetText("  flags: "));
 
 					// fixme: enough said vvv
@@ -956,7 +957,8 @@ static void COM_Help_f(void)
 					CONS_Printf("\n");
 				}
 
-				if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3)) {
+				if (!(cv_cvarinformation.value == 1 || cv_cvarinformation.value == 3))
+				{
 					if (!(cmd->flags & (COM_LUACOM | COM_CLIENT))) {
 						CONS_Printf("\tOrigin: Vanilla""\x82"" (Check wiki.srb2.org for more information)\n");
 					} else if (cmd->flags & COM_CLIENT && !(cmd->flags & COM_LUACOM))
@@ -1066,7 +1068,10 @@ static void COM_CONSLogicC_f(void)
 
 	// (im just lazy to switch it off from CONS_Debug)
 	if (!(cv_debug & DBG_GAMELOGIC))
+	{
 		CONS_Printf("DEVMODE must be enabled and set to gamelogic to use this.\n");
+		return;
+	}
 
 	for (cvar = consvar_vars; cvar; cvar = cvar->next)
 	{

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -323,10 +323,10 @@ static CV_PossibleValue_t chatx_cons_t[] = {{-BASEVIDWIDTH/2, "MIN"}, {BASEVIDWI
 static CV_PossibleValue_t chaty_cons_t[] = {{-BASEVIDHEIGHT/2, "MIN"}, {BASEVIDHEIGHT, "MAX"}, {0, NULL}};
 static CV_PossibleValue_t chats1_cons_t[] = {{V_SNAPTOLEFT, "Left"}, {V_SNAPTORIGHT, "Right"}, {0, NULL}};
 static CV_PossibleValue_t chats2_cons_t[] = {{V_SNAPTOTOP, "Top"}, {V_SNAPTOBOTTOM, "Bottom"}, {0, NULL}};
-consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE, chatx_cons_t, NULL);
-consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE, chaty_cons_t, NULL);
-consvar_t cv_chats1 = CVAR_INIT ("chatleftrightsnapping", "Left", CV_SAVE, chats1_cons_t, NULL);
-consvar_t cv_chats2 = CVAR_INIT ("chatupdownsnapping", "Bottom", CV_SAVE, chats2_cons_t, NULL);
+consvar_t cv_chatx = CVAR_INIT ("chatx", "13", CV_SAVE|CV_CLIENT, chatx_cons_t, NULL);
+consvar_t cv_chaty = CVAR_INIT ("chaty", "169", CV_SAVE|CV_CLIENT, chaty_cons_t, NULL);
+consvar_t cv_chats1 = CVAR_INIT ("chatleftrightsnapping", "Left", CV_SAVE|CV_CLIENT, chats1_cons_t, NULL);
+consvar_t cv_chats2 = CVAR_INIT ("chatupdownsnapping", "Bottom", CV_SAVE|CV_CLIENT, chats2_cons_t, NULL);
 
 // Pause game upon window losing focus
 consvar_t cv_pauseifunfocused = CVAR_INIT ("pauseifunfocused", "Yes", CV_SAVE, CV_YesNo, NULL);

--- a/src/locale/en.po
+++ b/src/locale/en.po
@@ -108,7 +108,7 @@ msgid "Total : %d\n"
 msgstr ""
 
 #: command.c:712
-msgid "Toggle <cvar_name> : Toggle the value of a cvar\n"
+msgid "Toggle <cvar> : Toggle the value of a cvar\n"
 msgstr ""
 
 #: command.c:718

--- a/src/locale/srb2.pot
+++ b/src/locale/srb2.pot
@@ -112,7 +112,7 @@ msgid "Total : %d\n"
 msgstr ""
 
 #: command.c:723
-msgid "Toggle <cvar_name> : Toggle the value of a cvar\n"
+msgid "Toggle <cvar> : Toggle the value of a cvar\n"
 msgstr ""
 
 #: command.c:729


### PR DESCRIPTION
this is basically just a modified `toggle`

`cvcycle <cvar> [values] [-r]`
Cycles given values on the given cvar as long as the current value is an argument. if not, bails unless `-r` is specified (starts at the first value then)

(ps. uses the color cvar as a demo; prints are from debugging stuff thats already removed (only except being)
https://github.com/user-attachments/assets/0d497478-2cfc-48b9-9a4b-39f1e027c07d

the point of this command is to not have 300 billion binds on changing cvar values. simplifies cases where you could just use `add`.

also fixes some formatting issues caused by the `COM_Help_f`->`CV_Command` changes

tested with binds, should work (unsure about string values with spaces in them due to not that many strvalues like such existing but eh)

(NOTE: Loop takes first instance if the current value is present more than once, and it just doesn't work for the name cvar, only the first instance at best...)

EDIT: this hardly working with name is probably for the better, being able to use it on color is already bad enough because of how bad a constant spam of large `XD_NAMEANDCOLOR` packets is (recursive `exec` file with `-silent` specified), especially with a stupidly long playername already.

command puts a lot of faith into the user, putting a client side restriction is pointless because the user can remove it, and a serverside restriction likely is too much of a hassle