### PR TITLE
Misc. toggles

### DIFF
--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -801,12 +801,14 @@ static void I_StartupConsole(void)
 	if (framebuffer)
 		consolevent = false;
 
+	consolevent = consolevent || M_CheckParm("-forceconsole")
+
 	if (!consolevent) return;
 
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = false;
+		consolevent = M_CheckParm("-forceconsole");
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -14351,7 +14351,7 @@ mobj_t *P_SPMAngle(mobj_t *source, mobjtype_t type, angle_t angle, UINT8 allowai
 //
 void P_FlashPal(player_t *pl, UINT16 type, UINT16 duration)
 {
-	if (!pl)
+	if (!pl || !cv_flashes.value)
 		return;
 	pl->flashcount = duration;
 	pl->flashpal = type;

--- a/src/r_main.c
+++ b/src/r_main.c
@@ -183,6 +183,8 @@ consvar_t cv_fullbrite_hack = CVAR_INIT ("fullbrite", "No", CV_NOINIT|CV_CLIENT,
 
 consvar_t cv_renderstats = CVAR_INIT ("renderstats", "Off", 0, CV_OnOff, NULL);
 
+consvar_t cv_flashes = CVAR_INIT ("flashes", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
+
 void SplitScreen_OnChange(void)
 {
 	if (!cv_debug && netgame)
@@ -1742,4 +1744,5 @@ void R_RegisterEngineStuff(void)
 	// Frame interpolation/uncapped
 	CV_RegisterVar(&cv_fpscap);
 
+	CV_RegisterVar(&cv_flashes);
 }

--- a/src/r_main.h
+++ b/src/r_main.h
@@ -132,6 +132,8 @@ extern consvar_t cv_ffloorclip, cv_spriteclip;
 extern consvar_t cv_pitchroll_rotation;
 extern consvar_t cv_pitchroll_easing;
 
+extern consvar_t cv_flashes;
+
 extern boolean r_renderwalls;
 extern boolean r_renderfloors;
 extern boolean r_renderthings;

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -569,12 +569,18 @@ static void I_StartupConsole(void)
 	if (framebuffer)
 		consolevent = SDL_FALSE;
 
+	if (M_CheckParm("-forceconsole"))
+		consolevent = SDL_TRUE;
+
 	if (!consolevent) return;
 
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = SDL_FALSE;
+
+		if (!M_CheckParm("-forceconsole"))
+			consolevent = SDL_FALSE;
+
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));

--- a/src/v_video.c
+++ b/src/v_video.c
@@ -86,7 +86,7 @@ static CV_PossibleValue_t constextsize_cons_t[] = {
 static void CV_constextsize_OnChange(void);
 consvar_t cv_constextsize = CVAR_INIT ("con_textsize", "Medium", CV_SAVE|CV_CALL, constextsize_cons_t, CV_constextsize_OnChange);
 
-consvar_t cv_menucaps = CVAR_INIT ("menucaps", "ON", CV_SAVE, CV_OnOff, NULL);
+consvar_t cv_menucaps = CVAR_INIT ("menucaps", "ON", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 // local copy of the palette for V_GetColor()
 RGBA_t *pLocalPalette = NULL;


### PR DESCRIPTION
Adds the `-forceconsole` parameter, the `flashes` console variable, and gives `menucaps` the CV_CLIENT flag.

`-forceconsole` forces console input to be enabled even when the game complains about having no tty.
`flashes` toggles the effect of P_FlashPal globally, controlling palette flashes for people with epilepsy.
![srb22671](https://github.com/user-attachments/assets/074f6e70-351b-40cd-bd5a-08e5b5513b26)

Both toggles suggested by @Sterrenhart.