### PR TITLE
fix: I/O when no TTY is connected behaves strangely.

### DIFF
--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -860,41 +860,36 @@ static void I_GetConsoleEvents(void)
 		if (read(STDIN_FILENO, &key, 1) == -1 || !key)
 			return;
 
-		// we have something
-		// backspace?
-		// NOTE TTimo testing a lot of values .. seems it's the only way to get it to work everywhere
-		if ((key == tty_erase) || (key == 127) || (key == 8))
-		{
-			if (tty_con.cursor > 0)
-			{
+		switch (key) {
+		default:
+			if (key == tty_erase); /* fallthrough */
+			else if (key < ' ') continue; // check if this is a control char
+			else if (tty_con.cursor < sizeof(tty_con.buffer)) {
+				// push regular character
+				ev.key = tty_con.buffer[tty_con.cursor] = key;
+				tty_con.cursor++;
+				/* Write the character for user feedback. */
+				write(STDOUT_FILENO, &key, 1);
+				break;
+			}
+			/* fallthrough */
+		case '\b':
+		case 127:
+			ev.key = KEY_BACKSPACE;
+			if (tty_con.cursor > 0) {
 				tty_con.cursor--;
 				tty_con.buffer[tty_con.cursor] = '\0';
 				tty_Back();
 			}
-			ev.key = KEY_BACKSPACE;
-		}
-		else if (key < ' ') // check if this is a control char
-		{
-			if (key == '\n')
-			{
-				tty_Clear();
-				tty_con.cursor = 0;
-				ev.key = KEY_ENTER;
-			}
-			else if (key == 0x4) // ^D, aka EOF
-			{
-				// shut down, most unix programs behave this way
-				I_Quit();
-			}
-			else continue;
-		}
-		else if (tty_con.cursor < sizeof(tty_con.buffer))
-		{
-			// push regular character
-			ev.key = tty_con.buffer[tty_con.cursor] = key;
-			tty_con.cursor++;
-			// print the current line (this is differential)
-			write(STDOUT_FILENO, &key, 1);
+			break;
+		case '\n':
+			ev.key = KEY_ENTER;
+			tty_Clear();
+			tty_con.cursor = 0;
+			break;
+		case 0x4: // ^D, aka EOF
+			// shut down, most unix programs behave this way
+			I_Quit();
 		}
 		if (ev.key) D_PostEvent(&ev);
 		//tty_FlushIn();

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -219,7 +219,8 @@ UINT8 graphics_started = 0;
 
 UINT8 keyboard_started = 0;
 
-static boolean consolevent = false;
+static boolean consolevent = false; /* Whether console events are processed. */
+static boolean consoleistty = true; /* Whether we're user or system facing. */
 #if defined (__unix__) || defined(__APPLE__) || defined (UNIXCOMMON)
 static boolean framebuffer = false;
 #endif
@@ -808,7 +809,7 @@ static void I_StartupConsole(void)
 	if (isatty(STDIN_FILENO)!=1)
 	{
 		I_OutputMsg("stdin is not a tty, tty console mode failed\n");
-		consolevent = M_CheckParm("-forceconsole");
+		consoleistty = false;
 		return;
 	}
 	memset(&tty_con, 0x00, sizeof(tty_con));
@@ -869,14 +870,15 @@ static void I_GetConsoleEvents(void)
 				ev.key = tty_con.buffer[tty_con.cursor] = key;
 				tty_con.cursor++;
 				/* Write the character for user feedback. */
-				write(STDOUT_FILENO, &key, 1);
+				if (consoleistty)
+					write(STDOUT_FILENO, &key, 1);
 				break;
 			}
 			/* fallthrough */
 		case '\b':
 		case 127:
 			ev.key = KEY_BACKSPACE;
-			if (tty_con.cursor > 0) {
+			if (consoleistty && tty_con.cursor > 0) {
 				tty_con.cursor--;
 				tty_con.buffer[tty_con.cursor] = '\0';
 				tty_Back();
@@ -884,8 +886,10 @@ static void I_GetConsoleEvents(void)
 			break;
 		case '\n':
 			ev.key = KEY_ENTER;
-			tty_Clear();
-			tty_con.cursor = 0;
+			if (consoleistty) {
+				tty_Clear();
+				tty_con.cursor = 0;
+			}
 			break;
 		case 0x4: // ^D, aka EOF
 			// shut down, most unix programs behave this way
@@ -1119,7 +1123,7 @@ void I_OutputMsg(const char *fmt, ...)
 	}
 #else
 #ifdef HAVE_TERMIOS
-	if (consolevent && ttycon_ateol)
+	if (consoleistty && ttycon_ateol)
 	{
 		tty_Clear();
 		ttycon_ateol = false;
@@ -1129,7 +1133,7 @@ void I_OutputMsg(const char *fmt, ...)
 	if (!framebuffer)
 		fprintf(stderr, "%s", txt);
 #ifdef HAVE_TERMIOS
-	if (consolevent && txt[len-1] == '\n')
+	if (consoleistty && txt[len-1] == '\n')
 	{
 		write(STDOUT_FILENO, tty_con.buffer, tty_con.cursor);
 		ttycon_ateol = true;


### PR DESCRIPTION
Included are two patches.
The first cleaning up the if..else monster by using a switch instead. I am aware that readability is partly a matter of preference, but I found that it was pretty safe to say that this piece of code was a little tricky to add things in a clean manner. Whether this is actually something that need be done is another question.

The second patch is the main change. This is re-opened from #59, since that patch faced the following problems:
* ``consoleistty`` is never set to ``true``. Which made the programme perform in tty-less mode always
* Input was actually not handled, because the ``\n`` control character was being ignored.
* Lastly, a small visual change where in non-tty mode characters written via STDIN were still being printed, leading to situations such as ``quit$quit`` ending up in the logs, where in tty-mode it'd be ``quit\r$quit``, thus showed as ``$quit``. non-tty mode now shows the same by never writing ``quit\r``.

Again, the missing semicolon is preserved. See https://github.com/luigi-budd/SRB2-edit/pull/59#issuecomment-4189556151 for a patch, though this'll more likely be fixed elsewhere.

For more information about individual patches, the relevant information has been included in the commit body, of course.