### PR TITLE
Save SRB2-edit cvars to a different config file

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -2804,13 +2804,17 @@ void CV_ClearChangedFlags(void)
   *
   * \param f File to save to.
   */
-void CV_SaveVariables(FILE *f)
+void CV_SaveVariables(FILE *f, boolean edit)
 {
 	consvar_t *cvar;
 
 	for (cvar = consvar_vars; cvar; cvar = cvar->next)
 		if (cvar->flags & CV_SAVE)
 		{
+			if ((!(cvar->flags & CV_CLIENT) && edit) || (cvar->flags & CV_CLIENT && !edit)) {
+				continue;
+			}
+
 			char stringtowrite[MAXTEXTCMD+1];
 
 			const char * string;

--- a/src/command.h
+++ b/src/command.h
@@ -128,7 +128,8 @@ typedef enum
 	CV_CHEAT = 2048, // Don't let this be used in multiplayer unless cheats are on.
 	CV_ALLOWLUA = 4096, // Let this be called from Lua
 	CV_LUAVAR = 8192, // Variable was created by Lua.
-	CV_CLIENT = 16384, // Variable is in SRB2-edit, but not Vanilla.
+	CV_CLIENT = 16384,	// Variable is in SRB2-edit, but not Vanilla
+						// (or has more values than in vanilla)
 } cvflags_t;
 
 typedef struct CV_PossibleValue_s
@@ -223,7 +224,7 @@ void CV_StealthSet(consvar_t *var, const char *value);
 void CV_AddValue(consvar_t *var, INT32 increment);
 
 // write all CV_SAVE variables to config file
-void CV_SaveVariables(FILE *f);
+void CV_SaveVariables(FILE *f, boolean edit);
 
 // load/save gamesate (load and save option and for network join in game)
 void CV_SaveVars(save_t *p, boolean in_demo);

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1166,6 +1166,9 @@ static void IdentifyVersion(addfilelist_t *startupwadfiles)
 	snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, srb2waddir);
 	configfile[sizeof configfile - 1] = '\0';
 
+	snprintf(editconfigfile, sizeof editconfigfile, "%s" PATHSEP EDITCONFIGFILENAME, srb2waddir);
+	editconfigfile[sizeof editconfigfile - 1] = '\0';
+
 	// Load the IWAD
 	if (srb2wad != NULL && FIL_ReadFileOK(srb2wad))
 		D_AddFile(startupwadfiles, srb2wad);
@@ -1330,8 +1333,10 @@ void D_SRB2Main(void)
 #else
 			if (dedicated)
 				snprintf(configfile, sizeof configfile, "d"CONFIGFILENAME);
+				snprintf(editconfigfile, sizeof editconfigfile, "d"EDITCONFIGFILENAME);
 			else
 				snprintf(configfile, sizeof configfile, CONFIGFILENAME);
+				snprintf(editconfigfile, sizeof editconfigfile, EDITCONFIGFILENAME);
 #endif
 		}
 		else
@@ -1340,10 +1345,13 @@ void D_SRB2Main(void)
 #ifdef DEFAULTDIR
 			snprintf(srb2home, sizeof srb2home, "%s" PATHSEP DEFAULTDIR, userhome);
 			snprintf(downloaddir, sizeof downloaddir, "%s" PATHSEP "DOWNLOAD", srb2home);
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d"CONFIGFILENAME, srb2home);
-			else
+				snprintf(editconfigfile, sizeof editconfigfile, "%s" PATHSEP "d"EDITCONFIGFILENAME, srb2home);
+			} else {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, srb2home);
+				snprintf(editconfigfile, sizeof editconfigfile, "%s" PATHSEP EDITCONFIGFILENAME, srb2home);
+			}
 
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, srb2home, PATHSEP);
@@ -1353,10 +1361,13 @@ void D_SRB2Main(void)
 #else // DEFAULTDIR
 			snprintf(srb2home, sizeof srb2home, "%s", userhome);
 			snprintf(downloaddir, sizeof downloaddir, "%s", userhome);
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP "d"CONFIGFILENAME, userhome);
-			else
+				snprintf(editconfigfile, sizeof editconfigfile, "%s" PATHSEP "d"EDITCONFIGFILENAME, userhome);
+			} else {
 				snprintf(configfile, sizeof configfile, "%s" PATHSEP CONFIGFILENAME, userhome);
+				snprintf(editconfigfile, sizeof editconfigfile, "%s" PATHSEP EDITCONFIGFILENAME, userhome);
+			}
 
 			// can't use sprintf since there is %u in savegamename
 			strcatbf(savegamename, userhome, PATHSEP);
@@ -1367,6 +1378,7 @@ void D_SRB2Main(void)
 		}
 
 		configfile[sizeof configfile - 1] = '\0';
+		editconfigfile[sizeof editconfigfile - 1] = '\0';
 	}
 
 	M_LoadJoinedIPs();	// load joined ips

--- a/src/d_main.c
+++ b/src/d_main.c
@@ -1331,12 +1331,13 @@ void D_SRB2Main(void)
 #if (defined (__unix__) || defined (__APPLE__) || defined (UNIXCOMMON)) && !defined (__CYGWIN__)
 			I_Error("Please set $HOME to your home directory\n");
 #else
-			if (dedicated)
+			if (dedicated) {
 				snprintf(configfile, sizeof configfile, "d"CONFIGFILENAME);
 				snprintf(editconfigfile, sizeof editconfigfile, "d"EDITCONFIGFILENAME);
-			else
+			} else {
 				snprintf(configfile, sizeof configfile, CONFIGFILENAME);
 				snprintf(editconfigfile, sizeof editconfigfile, EDITCONFIGFILENAME);
+			}
 #endif
 		}
 		else

--- a/src/dedicated/i_system.c
+++ b/src/dedicated/i_system.c
@@ -480,7 +480,8 @@ FUNCNORETURN static void I_QuitStatus(int status)
 		abort();
 
 	is_quitting = true;
-	M_SaveConfig(NULL); //save game config, cvars..
+	M_SaveConfig(NULL, false); //save game config, cvars..
+	M_SaveConfig(NULL, true); //srb2edit config
 	D_SaveBan(); // save the ban list
 	G_SaveGameData(clientGamedata); // Tails 12-08-2002
 	//added:16-02-98: when recording a demo, should exit using 'q' key,

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -822,7 +822,7 @@ void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis
 {
 	INT32 i;
 
-	for (i = (!edit ? 1 : NUM_GAMECONTROLS-EDITCUSTOMCONTROLS); i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < NUM_GAMECONTROLS; i++)
 	{
 		fprintf(f, "setcontrol \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrols[i][0]));
@@ -833,7 +833,7 @@ void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis
 			fprintf(f, "\n");
 	}
 
-	for (i = (!edit ? 1 : NUM_GAMECONTROLS-EDITCUSTOMCONTROLS); i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < NUM_GAMECONTROLS; i++)
 	{
 		fprintf(f, "setcontrol2 \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrolsbis[i][0]));

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -818,11 +818,11 @@ void G_CopyControls(INT32 (*setupcontrols)[2], INT32 (*fromcontrols)[2], const I
 	}
 }
 
-void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis)[2])
+void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis)[2], boolean edit)
 {
 	INT32 i;
 
-	for (i = 1; i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : NUM_GAMECONTROLS-EDITCUSTOMCONTROLS); i < NUM_GAMECONTROLS; i++)
 	{
 		fprintf(f, "setcontrol \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrols[i][0]));
@@ -833,7 +833,7 @@ void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis
 			fprintf(f, "\n");
 	}
 
-	for (i = 1; i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : NUM_GAMECONTROLS-EDITCUSTOMCONTROLS); i < NUM_GAMECONTROLS; i++)
 	{
 		fprintf(f, "setcontrol2 \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrolsbis[i][0]));

--- a/src/g_input.c
+++ b/src/g_input.c
@@ -822,7 +822,7 @@ void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis
 {
 	INT32 i;
 
-	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < (!edit ? VANILLACONTROLCOUNT : NUM_GAMECONTROLS); i++)
 	{
 		fprintf(f, "setcontrol \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrols[i][0]));
@@ -833,7 +833,7 @@ void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis
 			fprintf(f, "\n");
 	}
 
-	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < NUM_GAMECONTROLS; i++)
+	for (i = (!edit ? 1 : VANILLACONTROLCOUNT); i < (!edit ? VANILLACONTROLCOUNT : NUM_GAMECONTROLS); i++)
 	{
 		fprintf(f, "setcontrol2 \"%s\" \"%s\"", gamecontrolname[i],
 			G_KeyNumToName(fromcontrolsbis[i][0]));

--- a/src/g_input.h
+++ b/src/g_input.h
@@ -107,6 +107,10 @@ typedef enum
 	NUM_GAMECONTROLS
 } gamecontrols_e;
 
+// Increment this if you add a new GC_ (also make sure its after GC_CUSTOM3!)
+// this is used for saving SRB2-edit controls seperately
+#define EDITCUSTOMCONTROLS 1
+
 typedef enum
 {
 	gcs_custom,
@@ -196,7 +200,7 @@ void Command_Setcontrol2_f(void);
 void G_DefineDefaultControls(void);
 INT32 G_GetControlScheme(INT32 (*fromcontrols)[2], const INT32 *gclist, INT32 gclen);
 void G_CopyControls(INT32 (*setupcontrols)[2], INT32 (*fromcontrols)[2], const INT32 *gclist, INT32 gclen);
-void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis)[2]);
+void G_SaveKeySetting(FILE *f, INT32 (*fromcontrols)[2], INT32 (*fromcontrolsbis)[2], boolean edit);
 INT32 G_CheckDoubleUsage(INT32 keynum, boolean modify);
 
 // sets the members of a mouse_t given position deltas

--- a/src/g_input.h
+++ b/src/g_input.h
@@ -107,9 +107,7 @@ typedef enum
 	NUM_GAMECONTROLS
 } gamecontrols_e;
 
-// Increment this if you add a new GC_ (also make sure its after GC_CUSTOM3!)
-// this is used for saving SRB2-edit controls seperately
-#define EDITCUSTOMCONTROLS 1
+#define VANILLACONTROLCOUNT 43
 
 typedef enum
 {

--- a/src/hardware/hw_main.c
+++ b/src/hardware/hw_main.c
@@ -5879,7 +5879,7 @@ consvar_t cv_glmodellighting = CVAR_INIT ("gr_modellighting", "Off", CV_SAVE|CV_
 consvar_t cv_glmodeltranslations = CVAR_INIT ("gr_modeltranslations", "On", CV_SAVE|CV_CLIENT, CV_OnOff, NULL);
 
 consvar_t cv_glshearing = CVAR_INIT ("gr_shearing", "Off", CV_SAVE, glshearing_cons_t, NULL);
-consvar_t cv_glspritebillboarding = CVAR_INIT ("gr_spritebillboarding", "Off", CV_SAVE, glsprbillboard_cons_t, NULL);
+consvar_t cv_glspritebillboarding = CVAR_INIT ("gr_spritebillboarding", "Off", CV_SAVE|CV_CLIENT, glsprbillboard_cons_t, NULL);
 consvar_t cv_glskydome = CVAR_INIT ("gr_skydome", "On", CV_SAVE, CV_OnOff, NULL);
 consvar_t cv_glfakecontrast = CVAR_INIT ("gr_fakecontrast", "Smooth", CV_SAVE, glfakecontrast_cons_t, NULL);
 consvar_t cv_glslopecontrast = CVAR_INIT ("gr_slopecontrast", "Off", CV_SAVE, CV_OnOff, NULL);

--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -596,15 +596,18 @@ void M_LoadJoinedIPs(void)
 //
 
 char configfile[MAX_WADPATH];
+char editconfigfile[MAX_WADPATH];
 
 // ==========================================================================
 //                          CONFIGURATION
 // ==========================================================================
 static boolean gameconfig_loaded = false; // true once config.cfg loaded AND executed
+// archiNiko: now also waits until CV_CLIENT stuff is set (editconfig.cfg)
 
 /** Saves a player's config, possibly to a particular file.
   *
   * \sa Command_LoadConfig_f
+  * \todo editconfig support probably (will do eventually)
   */
 void Command_SaveConfig_f(void)
 {
@@ -619,7 +622,7 @@ void Command_SaveConfig_f(void)
 	strcpy(tmpstr, COM_Argv(1));
 	FIL_ForceExtension(tmpstr, ".cfg");
 
-	M_SaveConfig(tmpstr);
+	M_SaveConfig(tmpstr, false);
 	if (stricmp(COM_Argv(2), "-silent"))
 		CONS_Printf(M_GetText("config saved as %s\n"), configfile);
 }
@@ -627,6 +630,7 @@ void Command_SaveConfig_f(void)
 /** Loads a game config, possibly from a particular file.
   *
   * \sa Command_SaveConfig_f, Command_ChangeConfig_f
+  * \todo editconfig support probably (will do eventually)
   */
 void Command_LoadConfig_f(void)
 {
@@ -685,7 +689,14 @@ void M_FirstLoadConfig(void)
 	if (M_CheckParm("-config") && M_IsNextParm())
 	{
 		strcpy(configfile, M_GetNextParm());
-		CONS_Printf(M_GetText("config file: %s\n"), configfile);
+		CONS_Printf(M_GetText("SRB2 config file: %s\n"), configfile);
+	}
+
+	// srb2-edit edition
+	if (M_CheckParm("-editconfig") && M_IsNextParm())
+	{
+		strcpy(editconfigfile, M_GetNextParm());
+		CONS_Printf(M_GetText("SRB2-edit config file: %s\n"), editconfigfile); // archiNiko: maybe rephrase this?
 	}
 
 	// load default control
@@ -710,6 +721,9 @@ void M_FirstLoadConfig(void)
 	COM_BufInsertText(va("%s \"%d\"\n", cv_execversion.name, EXECVERSION));
 	CV_ToggleExecVersion(false);
 
+	// same except for srb2-edit client cvars
+	COM_BufInsertText(va("exec \"%s\"\n", editconfigfile));
+
 	// make sure I_Quit() will write back the correct config
 	// (do not write back the config if it crash before)
 	gameconfig_loaded = true;
@@ -725,10 +739,11 @@ void M_FirstLoadConfig(void)
 }
 
 /** Saves the game configuration.
-  *
+  * [SRB2-edit] OR edit config
+  * 
   * \sa Command_SaveConfig_f
   */
-void M_SaveConfig(const char *filename)
+void M_SaveConfig(const char *filename, boolean edit)
 {
 	FILE *f;
 	char *filepath;
@@ -756,7 +771,7 @@ void M_SaveConfig(const char *filename)
 		f = fopen(filepath, "w");
 		// change it only if valid
 		if (f)
-			strcpy(configfile, filepath);
+			strcpy((edit ? editconfigfile : configfile), filepath);
 		else
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save game config file %s\n"), filepath);
@@ -765,13 +780,13 @@ void M_SaveConfig(const char *filename)
 	}
 	else
 	{
-		if (!strstr(configfile, ".cfg"))
+		if (!strstr((edit ? editconfigfile : configfile), ".cfg"))
 		{
 			CONS_Alert(CONS_NOTICE, M_GetText("Config filename must be .cfg\n"));
 			return;
 		}
 
-		f = fopen(configfile, "w");
+		f = fopen((edit ? editconfigfile : configfile), "w");
 		if (!f)
 		{
 			CONS_Alert(CONS_ERROR, M_GetText("Couldn't save game config file %s\n"), configfile);
@@ -780,35 +795,37 @@ void M_SaveConfig(const char *filename)
 	}
 
 	// header message
-	fprintf(f, "// SRB2 configuration file.\n");
+	fprintf(f, "// SRB2%sconfiguration file\n", (edit ? "-edit " : " "));
 
-	// print execversion FIRST, because subsequent consvars need to be filtered
-	// always print current EXECVERSION
-	fprintf(f, "%s \"%d\"\n", cv_execversion.name, EXECVERSION);
+	if (!edit) {
+		// print execversion FIRST, because subsequent consvars need to be filtered
+		// always print current EXECVERSION
+		fprintf(f, "%s \"%d\"\n", cv_execversion.name, EXECVERSION);
+	}
 
 	// FIXME: save key aliases if ever implemented..
 
-	if (tutorialmode && tutorialgcs)
+	if ((tutorialmode && tutorialgcs) && !edit)
 	{
 		CV_SetValue(&cv_usemouse, tutorialusemouse);
 		CV_SetValue(&cv_alwaysfreelook, tutorialfreelook);
 		CV_SetValue(&cv_mousemove, tutorialmousemove);
 		CV_SetValue(&cv_analog[0], tutorialanalog);
-		CV_SaveVariables(f);
+		CV_SaveVariables(f, false);
 		CV_Set(&cv_usemouse, cv_usemouse.defaultvalue);
 		CV_Set(&cv_alwaysfreelook, cv_alwaysfreelook.defaultvalue);
 		CV_Set(&cv_mousemove, cv_mousemove.defaultvalue);
 		CV_Set(&cv_analog[0], cv_analog[0].defaultvalue);
 	}
 	else
-		CV_SaveVariables(f);
+		CV_SaveVariables(f, edit);
 
 	if (!dedicated)
 	{
 		if (tutorialmode && tutorialgcs)
-			G_SaveKeySetting(f, gamecontroldefault[gcs_custom], gamecontrolbis); // using gcs_custom as temp storage
+			G_SaveKeySetting(f, gamecontroldefault[gcs_custom], gamecontrolbis, edit); // using gcs_custom as temp storage
 		else
-			G_SaveKeySetting(f, gamecontrol, gamecontrolbis);
+			G_SaveKeySetting(f, gamecontrol, gamecontrolbis, edit);
 	}
 
 	fclose(f);

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -45,6 +45,9 @@ long int M_SavedSize(void);
 // the file where game vars and settings are saved
 #define CONFIGFILENAME "config.cfg"
 
+// cvars with CV_CLIENT (if they have CV_SAVE) go here
+#define EDITCONFIGFILENAME "editconfig.cfg"
+
 // The file where we'll save the last IPs we joined
 #define IPLOGFILE "srb2savedips.txt"
 #define IPLOGFILESEP ";"
@@ -99,7 +102,7 @@ void Command_ChangeConfig_f(void);
 
 void M_FirstLoadConfig(void);
 // save game config: cvars, aliases..
-void M_SaveConfig(const char *filename);
+void M_SaveConfig(const char *filename, boolean edit);
 
 INT32 axtoi(const char *hexStg);
 
@@ -148,5 +151,6 @@ int M_RoundUp(double number);
 
 #include "w_wad.h"
 extern char configfile[MAX_WADPATH];
+extern char editconfigfile[MAX_WADPATH];
 
 #endif

--- a/src/sdl/i_system.c
+++ b/src/sdl/i_system.c
@@ -2486,7 +2486,8 @@ void I_Quit(void)
 	if (quiting) goto death;
 	SDLforceUngrabMouse();
 	quiting = SDL_FALSE;
-	M_SaveConfig(NULL); //save game config, cvars..
+	M_SaveConfig(NULL, false); //save game config, cvars..
+	M_SaveConfig(NULL, true); //srb2edit config
 	M_SaveJoinedIPs(); // Not in dedicated because you shouldnt be able to connect there
 	D_SaveBan(); // save the ban list
 	G_SaveGameData(clientGamedata); // Tails 12-08-2002
@@ -2575,7 +2576,8 @@ void I_Error(const char *error, ...)
 			SDL_Quit();
 		if (errorcount == 8)
 		{
-			M_SaveConfig(NULL);
+			M_SaveConfig(NULL, false);
+			M_SaveConfig(NULL, true); // srb2edit config
 			G_SaveGameData(clientGamedata);
 		}
 		if (errorcount > 20)
@@ -2605,7 +2607,8 @@ void I_Error(const char *error, ...)
 	I_OutputMsg("\nI_Error(): %s\n", buffer);
 	// ---
 
-	M_SaveConfig(NULL); // save game config, cvars..
+	M_SaveConfig(NULL, false); // save game config, cvars..
+	M_SaveConfig(NULL, true); // srb2edit config
 	D_SaveBan(); // save the ban list
 	G_SaveGameData(clientGamedata); // Tails 12-08-2002
 


### PR DESCRIPTION
Currently you're gonna get a buttload of `Unknown command '<cvar>`' or `'<value>' is not a possible value for '<cvar>'` (latter only happening with `gr_spritebillboarding` ATM I believe, if I'm forgetting some then please yell at me) notices if you randomly decide to use vanilla instead of Edit again

obviously you can just use `-config`, but frankly that's a larger file than it needs to be

this PR just edits `CV_SaveVariables()`, `M_SaveConfig()` and `G_SaveKeySettings()` (for the sake of transparency theres also minor code duplication for the execution and saving of `editconfig.cfg` (editconfigfilename)), they all get a boolean "edit" param:

`CV_SaveVariables()` ignores cvars with `CV_CLIENT` if its edit boolean is false (or vice versa)
`M_SaveConfig()` gets sent to ternary hell
if `G_SaveKeySettings()`'s edit boolean is true, sets its index to `VANILLACONTROLCOUNT` (expands to 43) instead of 1, so it only saves whatevers past GC_CUSTOM3. Sadly this also meets ternary hell because I'm lazy.

Tried keeping code duplication to a minimum here.

`gr_spritebillboarding` is forcibly saved to the new SRB2-edit config (it got the `CV_CLIENT` flag) instead of the vanilla config.cfg to avoid the notices because i didnt want to make a whacky workaround thatd have to be used every time a vanilla var gets a new value added

(EDIT: also adds `-editconfig`, same as `-config` except for the seperated config)
only tested on Linux but pretty sure there's no OS-specific behaviour that clashes here